### PR TITLE
make lint usable without kind

### DIFF
--- a/ct.sh
+++ b/ct.sh
@@ -42,7 +42,7 @@ main() {
         return
     fi
 
-    if [ "$command" == "lint" ]; then
+    if [[ "$command" == "lint" ]]; then
         helm_init
     else
         configure_kube

--- a/ct.sh
+++ b/ct.sh
@@ -42,8 +42,13 @@ main() {
         return
     fi
 
-    configure_kube
-    install_tiller
+    if [ "$command" == "lint" ]; then
+        helm_init
+    else
+        configure_kube
+        install_tiller
+    fi
+
     run_ct
 }
 
@@ -129,6 +134,11 @@ install_tiller() {
     docker_exec sh -c 'kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin \
         --serviceaccount=kube-system:tiller --save-config --dry-run --output=yaml | kubectl apply -f -'
     docker_exec helm init --service-account tiller --upgrade --wait
+    echo
+}
+
+helm_init() {
+    docker_exec helm init --client-only
     echo
 }
 


### PR DESCRIPTION
Signed-off-by: André Bauer <andre.bauer@kiwigrid.com>

This PR makes "ct lint" command usable without kind by using "helm init --client-only" instead of full tiller install on a kind cluster.

This speeds up lint only commands where kind is not needed. 