### PR TITLE
Add support for Helm 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A GitHub Action to lint and test Helm charts, using the [helm/chart-testing](https://github.com/helm/chart-testing) CLI tool.
 
+`master` supports Helm 3 only.
+Support for Helm 2 is on branch `dev-v2`.
+
 ## Usage
 
 ### Pre-requisites

--- a/ct.sh
+++ b/ct.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-DEFAULT_IMAGE=quay.io/helmpack/chart-testing:v2.4.0
+DEFAULT_IMAGE=quay.io/helmpack/chart-testing:v3.0.0-beta.2
 
 show_help() {
 cat << EOF
@@ -47,12 +47,9 @@ main() {
     # charts changed.
     echo "::set-output name=changed::true"
 
-    if [[ "$command" == "lint" ]] || [[ "$command" == "list-changed" ]]; then
-        helm_init
     # All other ct commands require a cluster to be created in a previous step.
-    else
+    if [[ "$command" != "lint" ]] && [[ "$command" != "list-changed" ]]; then
         configure_kube
-        install_tiller
     fi
 
     run_ct
@@ -131,21 +128,6 @@ run_ct_container() {
 configure_kube() {
     docker_exec sh -c 'mkdir -p /root/.kube'
     docker cp "$kubeconfig" ct:/root/.kube/config
-}
-
-install_tiller() {
-    echo 'Installing Tiller...'
-    docker_exec sh -c 'kubectl create serviceaccount tiller --namespace kube-system --save-config --dry-run \
-        --output=yaml | kubectl apply -f -'
-    docker_exec sh -c 'kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin \
-        --serviceaccount=kube-system:tiller --save-config --dry-run --output=yaml | kubectl apply -f -'
-    docker_exec helm init --service-account tiller --upgrade --wait
-    echo
-}
-
-helm_init() {
-    docker_exec helm init --client-only
-    echo
 }
 
 run_ct() {


### PR DESCRIPTION
At the same time we drop support for Helm 2. Since actions are a new thing
and we don't have a major release yet, we decided to not support legacy.
Helm 2 users can still use older releases.

Signed-off-by: Reinhard Naegele <unguiculus@gmail.com>