### PR TITLE
Add support for additional docker arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ For more information on inputs, see the [API Documentation](https://developer.gi
 - `config`: The path to the config file
 - `command`: The chart-testing command to run
 - `kubeconfig`: The path to the kube config file
+- `dockerArgs`: Additional arguments which should be passed to docker when starting the ct container
 
 ### Example Workflow
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For more information on inputs, see the [API Documentation](https://developer.gi
 - `config`: The path to the config file
 - `command`: The chart-testing command to run
 - `kubeconfig`: The path to the kube config file
-- `dockerArgs`: Additional arguments which should be passed to docker when starting the ct container
+- `docker_args`: Additional arguments which should be passed to docker when starting the ct container
 
 ### Example Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   command:
     description: "The chart-testing command to run"
     required: true
-  dockerArgs:
+  docker_args:
     description: "Additional arguments which should be passed to docker when starting the ct container"
   kubeconfig:
     description: "The path to the kube config file"

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,8 @@ inputs:
   command:
     description: "The chart-testing command to run"
     required: true
+  dockerArgs:
+    description: "Additional arguments which should be passed to docker when starting the ct container"
   kubeconfig:
     description: "The path to the kube config file"
 outputs:

--- a/ct.sh
+++ b/ct.sh
@@ -24,7 +24,7 @@ main() {
     local config=
     local command=
     local kubeconfig="$HOME/.kube/config"
-    local dockerArgs=()
+    local docker_args=()
 
     parse_command_line "$@"
 
@@ -106,7 +106,7 @@ parse_command_line() {
                 ;;
             --docker-args)
                 if [[ -n "${2:-}" ]]; then
-                    IFS=" " read -r -a dockerArgs <<< "$2"
+                    IFS=" " read -r -a docker_args <<< "$2"
                     shift
                 else
                     echo "ERROR: '--docker-args' cannot be empty." >&2
@@ -131,7 +131,7 @@ run_ct_container() {
         args+=("--volume=$(pwd)/$config:/etc/ct/ct.yaml" )
     fi
 
-    args=("${args[@]}" "${dockerArgs[@]}")
+    args=("${args[@]}" "${docker_args[@]}")
 
     args+=("$image" cat)
 

--- a/main.sh
+++ b/main.sh
@@ -21,8 +21,8 @@ main() {
         args+=(--kubeconfig "${INPUT_KUBECONFIG}")
     fi
 
-    if [[ -n "${INPUT_DOCKERARGS:-}" ]]; then
-        args+=(--docker-args "${INPUT_DOCKERARGS}")
+    if [[ -n "${INPUT_DOCKER_ARGS:-}" ]]; then
+        args+=(--docker-args "${INPUT_DOCKER_ARGS}")
     fi
 
     "$SCRIPT_DIR/ct.sh" "${args[@]}"

--- a/main.sh
+++ b/main.sh
@@ -21,6 +21,10 @@ main() {
         args+=(--kubeconfig "${INPUT_KUBECONFIG}")
     fi
 
+    if [[ -n "${INPUT_DOCKERARGS:-}" ]]; then
+        args+=(--docker-args "${INPUT_DOCKERARGS}")
+    fi
+
     "$SCRIPT_DIR/ct.sh" "${args[@]}"
 }
 


### PR DESCRIPTION
This helps to add helm plugins or other tools to the `ct` container

```
ct.sh -c lint --docker-args "--volume=/home/user/.local/share/helm/plugins:/root/.local/share/helm/plugins --volume=/tools:/tools"
```

It's needed for https://github.com/helm/chart-testing/pull/283