### PR TITLE
docs: update kind-action version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ jobs:
         run: ct lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)


### PR DESCRIPTION
I often initialise new repos by copying from the actions README.md and this small change usually has me stumped for a bit until i realise that i've fixed it a few times before already.

Signed-off-by: Lucas Bickel <lucas.bickel@adfinis.com>