### PR TITLE
fix: Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --targer-branch main)
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi


### PR DESCRIPTION
PR #75 had a small typo in the args to `ct` - it should be `--target-branch`.

Also, rather than hard-coding `main`, we can use the event [context][1] to get the name of the
default branch if it's something different (eg `master`).

[1]: https://docs.github.com/en/actions/learn-github-actions/contexts
