### PR TITLE
docs: update README according to deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
         run: |
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)


### PR DESCRIPTION
GitHub is deprecating the `set-output` command. This sets the output parameter according to:
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

Warning from GitHub Action:

```
The `set-output` command is deprecated and will be disabled soon. Please
upgrade to using Environment Files. For more information see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```