### PR TITLE
chore: update README with new github workflow output syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
         run: |
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)


### PR DESCRIPTION
Update the example in the README to account for the new github workflow output syntax.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/