### PR TITLE
docs: only run chart install if changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct install
 ```
 


### PR DESCRIPTION
If the chart did not change no kind cluster will be created - also the `ct install` can not be triggered.

Signed-off-by: Marco Lecheler <marco@task.media>