### PR TITLE
docs: only run chart lint if changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster


### PR DESCRIPTION
If no change on the chart was detected the linting should not be executed.

related to #105