### PR TITLE
docs: align documentation with available version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.5.0
+        uses: helm/chart-testing-action@v2.4.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed


### PR DESCRIPTION
The current example in the documentation displays a version that is not yet released.