### PR TITLE
Fix the broken link for GitHub Help Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A GitHub Action for installing the [helm/chart-testing](https://github.com/helm/
 1. A GitHub repo containing a directory with your Helm charts (e.g: `charts`)
 1. A workflow YAML file in your `.github/workflows` directory.
   An [example workflow](#example-workflow) is available below.
-  For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file)
+  For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://docs.github.com/en/actions/writing-workflows/quickstart#creating-your-first-workflow)
 
 ### Inputs
 


### PR DESCRIPTION
Fix the broken link for creating workflow GitHub Help Documentation