### PR TITLE
feat: `uv_version` to pin `uv`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,11 +17,17 @@ inputs:
     description: "The yamale version to install (default: 6.0.0)"
     required: false
     default: '6.0.0'
+  uv_version:
+    description: "The uv version to install (default: latest)"
+    required: false
+    default: 'latest'
 runs:
   using: composite
   steps:
     - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
     - uses: astral-sh/setup-uv@eb1897b8dc4b5d5bfe39a428a8f2304605e0983c # v7.0.0
+      with:
+        version: ${{ inputs.uv_version }}
     - run: |
         cd $GITHUB_ACTION_PATH \
         && ./ct.sh \


### PR DESCRIPTION
Passes along the `version` value to [setup-uv](https://github.com/astral-sh/setup-uv?tab=readme-ov-file#inputs).

It can be considered best practice to pin this version a la supply-chain concerns, but more practically, this action hits the Github API if this is unset and we're getting rate-limited,

```
Run astral-sh/setup-uv@eb1897b8dc4b5d5bfe39a428a8f2304605e0983c
(node:1557) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Trying to find version for uv in: /home/runner/_work/onyx/onyx/uv.toml
Could not find file: /home/runner/_work/onyx/onyx/uv.toml
Trying to find version for uv in: /home/runner/_work/onyx/onyx/pyproject.toml
Could not determine uv version from uv.toml or pyproject.toml. Falling back to latest.
Getting latest version from GitHub API...
Error: Github API request failed while getting latest release. Check the GitHub status page for outages. Try again later.
Error: API rate limit exceeded for installation. If you reach out to GitHub Support for help, please include the request ID DFFE:3AC19:A0F67B:2C82286:695D8D30 and timestamp 2026-01-06 22:31:12 UTC. For more on scraping GitHub and how it may affect your rights, please review our Terms of Service (https://docs.github.com/en/site-policy/github-terms/github-terms-of-service) - https://docs.github.com/rest/overview/rate-limits-for-the-rest-api

```

Closes https://github.com/helm/chart-testing-action/issues/195