### PR TITLE
feat: add github_token input for setup-uv action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "The uv version to install (default: latest)"
     required: false
     default: 'latest'
+  github_token:
+    description: "GitHub token for authenticating with the GitHub API (default: github.token)"
+    required: false
+    default: ${{ github.token }}
 runs:
   using: composite
   steps:
@@ -28,6 +32,7 @@ runs:
     - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
       with:
         version: ${{ inputs.uv_version }}
+        github-token: ${{ inputs.github_token }}
     - run: |
         cd $GITHUB_ACTION_PATH \
         && ./ct.sh \


### PR DESCRIPTION
Allow users to specify a custom GitHub token for the astral-sh/setup-uv action. Defaults to the standard github.token if not provided.

This enables rate limit handling:

```
Getting latest version from GitHub API...
No (valid) GitHub token provided. Falling back to anonymous. Requests might be rate limited.
Error: API rate limit exceeded for x.x.x.x. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) - https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting
```
