### PR TITLE
feat: add option to disable blob verification

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -111,3 +111,36 @@ jobs:
     - name: Run chart-testing (install)
       if: steps.list-changed.outputs.changed == 'true'
       run: ct install --chart-dirs=testdata --target-branch ${{ github.event.repository.default_branch }}
+
+  test_ct_action_noverify:
+    runs-on: ubuntu-latest
+
+    name: Install chart-testing without verifiing blob and test presence in path
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        fetch-depth: 0
+    - name: Install chart-testing
+      uses: ./
+      with:
+        verify_blob: 'false'
+    - name: Check install!
+      run: |
+        ct version
+        CT_VERSION_OUTPUT=$(ct version 2>&1 /dev/null)
+        ACTUAL_VERSION=$(echo "$CT_VERSION_OUTPUT" | grep Version | rev | cut -d ' ' -f1 | rev)
+        if [[ $ACTUAL_VERSION != 'v3.14.0' ]]; then
+          echo 'should be v3.14.0'
+          exit 1
+        else
+          exit 0
+        fi
+      shell: bash
+    - name: Check root directory
+      run: |
+        if [[ $(git diff --stat) != '' ]]; then
+          echo 'should be clean'
+          exit 1
+        else
+          exit 0
+        fi

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ branding:
   color: blue
   icon: anchor
 inputs:
+  verify_blob:
+    description: "determines whether the download blob should be verified (default: true)"
+    required: false
+    default: 'true'
   version:
     description: "The chart-testing version to install"
     required: false
@@ -25,12 +29,14 @@ runs:
   using: composite
   steps:
     - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+      if: ${{ inputs.verify_blob != 'false' }}
     - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
       with:
         version: ${{ inputs.uv_version }}
     - run: |
         cd $GITHUB_ACTION_PATH \
         && ./ct.sh \
+            --verify-blob ${{ inputs.verify_blob }} \
             --version ${{ inputs.version }} \
             --yamllint-version ${{ inputs.yamllint_version }} \
             --yamale-version ${{ inputs.yamale_version }}

--- a/ct.sh
+++ b/ct.sh
@@ -5,6 +5,7 @@ set -o nounset
 set -o pipefail
 
 DEFAULT_CHART_TESTING_VERSION=3.14.0
+DEFAULT_VERIFY_BLOB=true
 DEFAULT_YAMLLINT_VERSION=1.33.0
 DEFAULT_YAMALE_VERSION=6.0.0
 
@@ -19,6 +20,7 @@ EOF
 
 main() {
     local version="${DEFAULT_CHART_TESTING_VERSION}"
+    local verify_blob="${DEFAULT_VERIFY_BLOB}"
     local yamllint_version="${DEFAULT_YAMLLINT_VERSION}"
     local yamale_version="${DEFAULT_YAMALE_VERSION}"
 
@@ -33,6 +35,16 @@ parse_command_line() {
             -h|--help)
                 show_help
                 exit
+                ;;
+            --verify-blob)
+                if [[ -n "${2:-}" ]]; then
+                    verify_blob="${2#v}"
+                    shift
+                else
+                    echo "ERROR: '--verify-blob' cannot be empty." >&2
+                    show_help
+                    exit 1
+                fi
                 ;;
             -v|--version)
                 if [[ -n "${2:-}" ]]; then
@@ -88,21 +100,28 @@ install_chart_testing() {
     local cache_dir="${RUNNER_TOOL_CACHE}/ct/${version}/${arch}"
     local venv_dir="${cache_dir}/venv"
 
+    curl --retry 5 --retry-delay 1 -sSLo ct.tar.gz \
+      "https://github.com/helm/chart-testing/releases/download/v${version}/chart-testing_${version#v}_linux_${arch}.tar.gz"
+    echo "Installing chart-testing v${version}..."
+
     if [[ ! -d "${cache_dir}" ]]; then
         mkdir -p "${cache_dir}"
 
-        echo "Installing chart-testing v${version}..."
-        CT_CERT=https://github.com/helm/chart-testing/releases/download/v${version}/chart-testing_${version#v}_linux_${arch}.tar.gz.pem
-        CT_SIG=https://github.com/helm/chart-testing/releases/download/v${version}/chart-testing_${version#v}_linux_${arch}.tar.gz.sig
+        if [[ "${verify_blob}" != "false" ]]; then
+            echo "Verifing blob..."
+            CT_CERT=https://github.com/helm/chart-testing/releases/download/v${version}/chart-testing_${version#v}_linux_${arch}.tar.gz.pem
+            CT_SIG=https://github.com/helm/chart-testing/releases/download/v${version}/chart-testing_${version#v}_linux_${arch}.tar.gz.sig
 
-        curl --retry 5 --retry-delay 1 -sSLo ct.tar.gz "https://github.com/helm/chart-testing/releases/download/v${version}/chart-testing_${version#v}_linux_${arch}.tar.gz"
-        cosign verify-blob --certificate "${CT_CERT}" --signature "${CT_SIG}" \
-          --certificate-identity "https://github.com/helm/chart-testing/.github/workflows/release.yaml@refs/heads/main" \
-          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ct.tar.gz
-        retVal=$?
-        if [[ "${retVal}" -ne 0 ]]; then
-          log_error "Unable to validate chart-testing version: v${version}"
-          exit 1
+            cosign verify-blob --certificate "${CT_CERT}" --signature "${CT_SIG}" \
+              --certificate-identity "https://github.com/helm/chart-testing/.github/workflows/release.yaml@refs/heads/main" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ct.tar.gz
+            retVal=$?
+            if [[ "${retVal}" -ne 0 ]]; then
+              log_error "Unable to validate chart-testing version: v${version}"
+              exit 1
+            fi
+        else
+            echo "Skipping verifing blob..."
         fi
 
         tar -xzf ct.tar.gz -C "${cache_dir}"


### PR DESCRIPTION
I have the issue that the address `sigstore.dev` is not shared on my runner (we do not like to open it).
So i would like to disable the verification by option.

Therefore I created a input to disable the verification in the action.
With the default Action configuration the sensible verification is enabled for sure.

This PR is the updated version of PR #131 which was closed due to inactivity.