### PR TITLE
fix: report a clear error when chart-testing blob verification fails

### DIFF
--- a/ct.sh
+++ b/ct.sh
@@ -96,12 +96,10 @@ install_chart_testing() {
         CT_SIG=https://github.com/helm/chart-testing/releases/download/v${version}/chart-testing_${version#v}_linux_${arch}.tar.gz.sig
 
         curl --retry 5 --retry-delay 1 -sSLo ct.tar.gz "https://github.com/helm/chart-testing/releases/download/v${version}/chart-testing_${version#v}_linux_${arch}.tar.gz"
-        cosign verify-blob --certificate "${CT_CERT}" --signature "${CT_SIG}" \
+        if ! cosign verify-blob --certificate "${CT_CERT}" --signature "${CT_SIG}" \
           --certificate-identity "https://github.com/helm/chart-testing/.github/workflows/release.yaml@refs/heads/main" \
-          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ct.tar.gz
-        retVal=$?
-        if [[ "${retVal}" -ne 0 ]]; then
-          log_error "Unable to validate chart-testing version: v${version}"
+          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ct.tar.gz; then
+          echo "ERROR: Unable to validate chart-testing version: v${version}" >&2
           exit 1
         fi
 


### PR DESCRIPTION
Under `set -o errexit`, the `retVal=$?` check after `cosign verify-blob` was
unreachable: a non-zero `cosign verify-blob` aborts the script immediately, so
the intended "Unable to validate chart-testing version" message never fired. The
error branch also called `log_error`, which is not defined anywhere in `ct.sh`
(it would fail with `command not found` if it were ever reached).

This rewrites the check as `if ! cosign verify-blob ...; then`, which suspends
errexit for the tested command so the failure branch is actually reached, and
replaces the undefined `log_error` with `echo "ERROR: ..." >&2`, matching the
existing error style used in `parse_command_line`. Behavior on success is
unchanged; on verification failure the script now prints the intended clear
error and exits 1.

Validation:
- `bash -n ct.sh` and `zsh -n ct.sh` parse clean
- `shellcheck ct.sh` clean
- Confirmed in both bash and zsh that `if ! cmd` reaches the failure branch under `set -o errexit`

Note: open PR #205 wraps this same block in a `verify_blob` toggle but copies the
broken `retVal`/`log_error` pattern verbatim, so this fix is complementary
regardless of merge order.