### PR TITLE
run test-action workflow on push

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -2,6 +2,7 @@ name: test-chart-testing-action
 
 on:
   pull_request:
+  push:
 
 jobs:
   test_ct_action:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the `test-chart-testing-action` (`test-action.yml`) workflow is run only for pull requests.  This change enables the action for `push` events.

Benefits:

- Contributors can get early feedback on their changes even before creating pull requests, by looking at workflow results in their forks.
- Commits on `main` will also have CI status associated.

## How was this patch tested?

Workflow run in fork:
https://github.com/adoroszlai/chart-testing-action/actions/runs/28318822653