### PR TITLE
Add uv cache toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ For more information on inputs, see the [API Documentation](https://developer.gi
 - `version`: The chart-testing version to install (default: `3.14.0`)
 - `yamllint_version`: The `yamllint` version to install (default: `1.33.0`)
 - `yamale_version`: The `yamale` version to install (default: `6.0.0`)
+- `uv_version`: The `uv` version to install (default: `latest`)
+- `uv_enable_cache`: Enable `uv` cache. Supported values: `true`, `false`, `auto` (default: `auto`)
 
 ### Example Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "The uv version to install (default: latest)"
     required: false
     default: 'latest'
+  uv_enable_cache:
+    description: "Enable uv cache. Supported values: true, false, auto."
+    required: false
+    default: 'auto'
 runs:
   using: composite
   steps:
@@ -28,6 +32,7 @@ runs:
     - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
       with:
         version: ${{ inputs.uv_version }}
+        enable-cache: ${{ inputs.uv_enable_cache }}
     - run: |
         cd $GITHUB_ACTION_PATH \
         && ./ct.sh \


### PR DESCRIPTION
## What this PR does

Adds a `uv_enable_cache` input and passes it through to `astral-sh/setup-uv` as `enable-cache`.

This lets users disable uv caching when chart-testing is used in repositories without Python dependency files, avoiding warnings like:

```text
No file matched to [...]. The cache will never get invalidated.
```

The default remains `auto`, matching setup-uv's current default behavior.

## Testing

- Parsed `action.yml` and workflow YAML with Ruby's YAML parser.
