### PR TITLE
Bump astral-sh/setup-uv from 7.3.0 to 8.2.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
   using: composite
   steps:
     - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-    - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+    - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         version: ${{ inputs.uv_version }}
     - run: |


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump `astral-sh/setup-uv` from 7.3.0 to 8.2.0.

## How was this patch tested?

Tested together with #212 (enabling test workflow run on `push` event).  Workflow run in my fork:

```
Run astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
```

https://github.com/adoroszlai/chart-testing-action/actions/runs/28455339002/job/84328458719#step:5:281